### PR TITLE
Added release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+# Docs: https://github.com/release-drafter/release-drafter/
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+autolabeler:
+  # the major label is not set automatically, but should be set explicitly if there are any breaking changes.  
+
+  - label: 'minor'
+    branch:
+      - '/feature\/.+/'
+  - label: 'patch'
+    branch:
+      - '/bug\/.+/'
+      - '/docs\/.+/'
+      - '/fix\/.+/'
+      - '/patch\/.+/'      
+  
+template: |
+  ## Changes
+
+  $CHANGES

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # .github
 
 Contains common files Github Action files
-
-Scaffolded from [backstage-template-empty-repository](https://github.com/lunarway/backstage-template-empty-repository)


### PR DESCRIPTION
This change adds a release-drafter configuration file which is supposed to be reused from release-drafter Github Actions