### PR TITLE
Link to full changelog in releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -30,3 +30,5 @@ template: |
   ## Changes
 
   $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
Currently, the release notes only link to each separate change where sometimes it would be useful to easily see the full list of changes in one view.

This change adds a link to a compare view so it is only one click away. Inspired by release-drafters own configuration