### PR TITLE
Add dependabot to autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,8 @@ autolabeler:
       - '/bug\/.+/'
       - '/docs\/.+/'
       - '/fix\/.+/'
-      - '/patch\/.+/'      
+      - '/patch\/.+/'
+      - '/dependabot\/.+/'
   
 template: |
   ## Changes


### PR DESCRIPTION
Dependabot will patch dependencies on branches starting with "dependabot/" so we
can make the auto labeler detect this making it more clear what change impact it
has on modules.