### PR TITLE
Revert change from #3

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -25,7 +25,6 @@ autolabeler:
       - '/docs\/.+/'
       - '/fix\/.+/'
       - '/patch\/.+/'
-      - '/dependabot\/.+/'
 
 template: |
   ## Changes


### PR DESCRIPTION
Currently, Dependabot PRs `release-drafter` actions fail as there is insufficient permissions to apply labels.

For now we are rolling back.

This change reverts #3