### PR TITLE
Fix shuttle name

### DIFF
--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,6 +1,6 @@
 plan: false
 
 vars:
-  service: .github
+  service: github
   squad: aura
   domain: developer-productivity


### PR DESCRIPTION
. is not allowed as the first character.