### PR TITLE
Replace all placeholders in template

### DIFF
--- a/.github/workflows/backstage-template-go-build-test.yml
+++ b/.github/workflows/backstage-template-go-build-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           templatedModuleName='go.lunarway.com/${{ '${{values.name}}' }}'
           validModuleName='go.lunarway.com/update'
-          sed -i "s|$templatedModuleName|$validModuleName|" ./template/go.mod ./template/cmd/main.go
+          find ./template -type f -exec sed -i "s|$templatedModuleName|$validModuleName|" {} +
 
       # enable access to private Git repositories
       - name: Configure git for private modules


### PR DESCRIPTION
Currently we only replace template placeholders in the backstage template
workflow for specific files. This change makes it replace all templated files
found for more generic support.