### PR TITLE
Added categories section to release drafter to group dependabot PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -26,6 +26,12 @@ autolabeler:
       - '/fix\/.+/'
       - '/patch\/.+/'
 
+categories:
+  - title: "Dependency Updates"
+    collapse-after: 3
+    labels:
+      - "dependencies"
+
 template: |
   ## Changes
 


### PR DESCRIPTION
currently, dependabot PRs creates some noise.

This change tries to use https://github.com/release-drafter/release-drafter/#categorize-pull-requests
 in order to group dependabot PRs in release notes.