### PR TITLE
Skip changelog on skip-changelog label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ autolabeler:
 
   - label: "minor"
     branch:
-      - '/feature\/.+/'      
+      - '/feature\/.+/'
       - '/feat\/.+/'
   - label: "patch"
     branch:
@@ -27,6 +27,9 @@ autolabeler:
       - '/fix\/.+/'
       - '/patch\/.+/'
       - '/chore\/.+/'
+
+exclude-labels:
+  - "skip-changelog"
 
 categories:
   - title: "Dependency Updates"


### PR DESCRIPTION
Sometimes, we want to skip the changelog when merging a PR. This change allows for that.