### PR TITLE
Update author field in Update Dependencies workflow

### DIFF
--- a/.github/workflows/backstage-template-go-dependency-update.yml
+++ b/.github/workflows/backstage-template-go-dependency-update.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.personalAccessToken }}
           commit-message: Update dependencies
           committer: ${{ inputs.committer }}
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          author: ${{ inputs.committer }}
           signoff: true
           branch: patch/dependencies
           delete-branch: true


### PR DESCRIPTION
Based on [GH community discussion](https://github.com/orgs/community/discussions/62108#discussioncomment-6581192):
> Github.actor is the latest person to schedule/trigger the workflow. If user A creates/schedules a workflow, github.actor is that user. If user B modifies the schedule setting or something that deals with triggering the workflow, github.actor is user B.

Apparently BSO/crevil is that person ([e.g. this run](https://github.com/lunarway/backstage-template-go-service-vostok/actions/runs/16874281346/job/47795092141)):

<img width="1667" height="1195" alt="image" src="https://github.com/user-attachments/assets/a56bba82-e148-4e4a-8697-1dc656024abe" />


Fixes ESA-417