### PR TITLE
CIT repository codeowner move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-esa
+* @lunarway/company-it

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -2,5 +2,5 @@ plan: false
 
 vars:
   service: github
-  squad: esa
+  squad: cit
   domain: developer-productivity


### PR DESCRIPTION
Set Company-IT as CODEOWNER and update repository metadata to reflect the move to the CIT repository.

This change aligns with issue CIT-797 and follows prior ownership migration patterns that updated both `CODEOWNERS` and `shuttle.yaml`.

---
Linear Issue: [CIT-797](https://linear.app/lunar/issue/CIT-797/set-company-it-as-codeowner-and-move-to-cit-repository)

<p><a href="https://cursor.com/agents/bc-84314bc7-d061-41c4-ade6-bf3532e61250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84314bc7-d061-41c4-ade6-bf3532e61250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

