### PR TITLE
feat(ci): add dependencies label to dependency update PRs

### DIFF
--- a/.github/workflows/backstage-template-go-dependency-update.yml
+++ b/.github/workflows/backstage-template-go-dependency-update.yml
@@ -87,6 +87,7 @@ jobs:
           branch: patch/dependencies
           delete-branch: true
           title: "Update dependencies"
+          labels: dependencies
           body: |
             This is an automated update of dependencies
           team-reviewers: |


### PR DESCRIPTION
## Summary

- Adds `labels: dependencies` to the `peter-evans/create-pull-request` step in the backstage Go dependency update workflow

## Why

Dependency-review tooling uses the `dependencies` label to identify and process automated dependency update PRs automatically.

> **Note:** The `dependencies` label must exist in each consuming repository for it to be applied. If missing, the PR is created without the label (no workflow failure).

Closes ESA-1614

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a PR label in a GitHub Actions workflow and does not affect application/runtime code. Only potential impact is workflow behavior if the `dependencies` label is missing in a target repo (label application will be skipped).
> 
> **Overview**
> Automated dependency-update PRs created by `.github/workflows/backstage-template-go-dependency-update.yml` are now tagged with the `dependencies` label via the `peter-evans/create-pull-request` step, enabling downstream dependency-review tooling to detect and process them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82aaa6fc2f64970d2c3d441bbd6ef0b9ff3bdc4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->