### PR TITLE
feat: add houston endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # .github
 
 Contains common files Github Action files
+
+## Houston endpoints
+
+Houston can be accessed through endpoint definitions in `shuttle.yaml`:
+
+- `vars.houston.endpoints.modules`
+- `vars.houston.endpoints.structure`
+- `vars.houston.endpoints.health`
+
+Any Shuttle plan or workflow in this repository can read these values and use them
+when making endpoint-based Houston calls.

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -4,3 +4,9 @@ vars:
   service: github
   squad: esa
   domain: developer-productivity
+  houston:
+    # Endpoint map used by plans/workflows that integrate with Houston.
+    endpoints:
+      modules: /houston/modules
+      structure: /houston/module-structure
+      health: /houston/health


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `vars.houston.endpoints` map in `shuttle.yaml`
- define endpoint paths for modules, module structure, and health
- document Houston endpoint access in the root `README.md`

## Why
This makes Houston endpoint access explicit and reusable for Shuttle plans/workflows in this repository.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5280436-2809-40ef-a20f-5e6c337927b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5280436-2809-40ef-a20f-5e6c337927b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

