### PR TITLE
chore: transfer ownership to squad-dark-matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-esa
+* @lunarway/squad-dark-matter

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -2,5 +2,5 @@ plan: false
 
 vars:
   service: github
-  squad: esa
+  squad: dark-matter
   domain: developer-productivity


### PR DESCRIPTION
Updates CODEOWNERS and shuttle.yaml to point to squad-dark-matter.

Part of [DMAT-8](https://linear.app/lunar/issue/DMAT-8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CODEOWNERS and a config value in `shuttle.yaml`, with no runtime logic changes.
> 
> **Overview**
> Transfers code ownership by updating `CODEOWNERS` to `@lunarway/squad-dark-matter` and changes `shuttle.yaml`’s `vars.squad` from `esa` to `dark-matter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ebe3b6a0847c8a479a14cf555a299cc1ca02b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->